### PR TITLE
Tradução catch-misspelled-variable-and-function-names

### DIFF
--- a/content/02-javascript-algorithms-and-data-structures/debugging/catch-misspelled-variable-and-function-names.md
+++ b/content/02-javascript-algorithms-and-data-structures/debugging/catch-misspelled-variable-and-function-names.md
@@ -1,6 +1,6 @@
 ---
 id: 587d7b84367417b2b2512b35
-title: Catch Misspelled Variable and Function Names
+title: Identificar variáveis e nomes de funções com erros de digitação
 challengeType: 1
 forumTopicId: 301186
 dashedName: catch-misspelled-variable-and-function-names
@@ -8,41 +8,39 @@ dashedName: catch-misspelled-variable-and-function-names
 
 # --description--
 
-The `console.log()` and `typeof` methods are the two primary ways to check intermediate values and types of program output. Now it's time to get into the common forms that bugs take. One syntax-level issue that fast typers can commiserate with is the humble spelling error.
+Os métodos `console.log()` e `typeof` são as duas principais formas de verificar valores intermediários e tipos de saída do programa. Agora é hora de entrar nas formas comuns que os bugs assumem. Um problema de nível de sintaxe com o qual digitadores rápidos podem lamentar é o humilde erro de ortografia.
 
-Transposed, missing, or mis-capitalized characters in a variable or function name will have the browser looking for an object that doesn't exist - and complain in the form of a reference error. JavaScript variable and function names are case-sensitive.
+Caracteres transpostos, ausentes ou mal capitalizados em uma variável ou nome de função farão com que o navegador procure um objeto que não existe - e reclame na forma de um erro de referência. Os nomes de variáveis e funções em JavaScript diferenciam maiúsculas de minúsculas.
 
 # --instructions--
 
-Fix the two spelling errors in the code so the `netWorkingCapital` calculation works.
+Corrija os dois erros de digitação no código para que o cálculo `netWorkingCapital` funcione.
 
 # --hints--
 
-Check the spelling of the two variables used in the netWorkingCapital calculation, the console output should show that "Net working capital is: 2".
+Verifique a grafia das duas variáveis usadas no cálculo de netWorkingCapital, a saída do console deve mostrar que "Net working capital is: 2".
 
 ```js
 assert(netWorkingCapital === 2);
 ```
 
-There should be no instances of mis-spelled variables in the code.
+Não deve haver instâncias de variáveis com erros de digitação no código.
 
 ```js
 assert(!code.match(/recievables/g));
 ```
-
-The `receivables` variable should be declared and used properly in the code.
+A variável `receivables` deve ser declarada e usada corretamente no código.
 
 ```js
 assert(code.match(/receivables/g).length == 2);
 ```
 
-There should be no instances of mis-spelled variables in the code.
+Não deve haver instâncias de variáveis com erros de digitação no código.
 
 ```js
 assert(!code.match(/payable;/g));
 ```
-
-The `payables` variable should be declared and used properly in the code.
+A variável `payables` deve ser declarada e usada corretamente no código.
 
 ```js
 assert(code.match(/payables/g).length == 2);


### PR DESCRIPTION
Tradução para pt-BR das seções **Descrição**, **Instruções** e **Dicas**, do arquivo `catch-misspelled-variable-and-function-names.md`